### PR TITLE
Update download links in landing page to point to GitHub releases

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -107,19 +107,19 @@
         <h1>Processing <br>Collaborative Editor</h1>
         <h2>Beta (v 1.0.4)</h2>
         <div class="button_wrapper">
-            <a href="https://drive.google.com/file/d/128fufgKMaag2QE-njDXdI5EYyG3BOVjr/view?usp=drive_link">
+            <a href="https://github.com/doradocodes/processing-collab-editor/releases/download/v1.0.4/Processing.Collaborative.Editor-darwin-arm64-1.0.4.zip">
                 <button>
                     <img src="./assets/Apple_logo_black.svg" alt="Download for MacOS" />
                     Download for Mac (Apple Silicon)
                 </button>
             </a>
-            <a href="https://drive.google.com/file/d/1986W414LR3zqTXMH_N8SWvMFRXQZDCKn/view?usp=drive_link">
+            <a href="https://github.com/doradocodes/processing-collab-editor/releases/download/v1.0.4/Processing.Collaborative.Editor-darwin-x64-1.0.4.zip">
                 <button>
                     <img src="./assets/Apple_logo_black.svg" alt="Download for MacOS" />
                     Download for Mac (Intel)
                 </button>
             </a>
-            <a href="https://drive.google.com/file/d/18UEokkVyqt_ODqKYlZwQG3V-sA3S7lHV/view?usp=sharing">
+            <a href="https://github.com/doradocodes/processing-collab-editor/releases/download/v1.0.4/Processing.Collaborative.Editor-win32-x64-1.0.4.zip">
                 <button>
                     <img src="./assets/windows-logo.png" alt="Download for Windows" />
                     Download for Windows


### PR DESCRIPTION
Point the download buttons directly to the artifacts in the 1.0.4 GitHub release instead of Google Drive